### PR TITLE
Add GitHub Actions workflow for build and deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,89 @@
+name: Build and Deploy Service History Lambda
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint with ruff
+        run: |
+          ruff check .
+          ruff format --check .
+
+      - name: Type check with mypy
+        run: mypy src
+
+      - name: Test with pytest
+        run: pytest
+
+  deploy:
+    name: Deploy
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.0"
+
+      - name: Terraform Init
+        working-directory: ./terraform
+        run: terraform init
+
+      - name: Terraform Validate
+        working-directory: ./terraform
+        run: terraform validate
+
+      - name: Terraform Plan
+        working-directory: ./terraform
+        run: terraform plan -out=tfplan
+
+      - name: Terraform Apply
+        working-directory: ./terraform
+        run: terraform apply -auto-approve tfplan


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate testing and deployment for the Service History Lambda. The workflow includes steps for testing the codebase with linting, type checking, and unit tests, as well as deploying infrastructure using Terraform.

### New GitHub Actions Workflow:

* `.github/workflows/deploy.yml`: Introduced a workflow named "Build and Deploy Service History Lambda" that triggers on pushes and pull requests to the `main` branch, as well as manual dispatches. It consists of two jobs:
  - **Test Job**: Runs on `ubuntu-latest` and includes steps for checking out the code, setting up Python 3.9, installing dependencies, linting with `ruff`, type checking with `mypy`, and running tests with `pytest`.
  - **Deploy Job**: Runs on `ubuntu-latest` and depends on the successful completion of the test job. It includes steps for setting up Python 3.9, configuring AWS credentials, initializing and validating Terraform, and applying Terraform plans to deploy infrastructure. This job only runs on pushes to the `main` branch.